### PR TITLE
Fix HAN Enabler for 4.92

### DIFF
--- a/html/ps3xploit.js
+++ b/html/ps3xploit.js
@@ -935,8 +935,8 @@ var gadget_mod13_addr_492=0x336870; //store_r3 gadget
 var gadget_mod14_addr_492=0x633900; //load r3 dword
 var gadget_mod15_addr_492=0x39D038; //load r3 word
 var gadget_mod16_addr_492=0x4F732C; //set toc
-var ipf1_addr_491=0x6ebb78; 
-var ipf2_addr_491=0x507374; 
+var ipf1_addr_492=0x6ebb78; 
+var ipf2_addr_492=0x507374; 
 
 function hexh2bin(hex_val)
 {


### PR DESCRIPTION
Hey ! i tried using enabling HAN and realized it just freeze on 4.92.

I went searching and found this : https://www.psx-place.com/threads/enable-han-freezes-ps3.40500/

So i checked and found the issue was almost the exact same. You can just check the commit.

Enabling HAN is now fully working on 4.92 too.